### PR TITLE
Add Trainer agent and improve demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This is the foundation of a sandbox-style ecosystem for intelligent agents. We�
    python main.py
    ```
 
-The demo spawns four agents—Builder, Thinker, Artist, and Guardian—who work together on a simple mission. Results are printed to the console and stored in a local SQLite database (`memory/memory.db`).
+The demo spawns five agents—Builder, Thinker, Artist, Guardian, and Trainer—who work together on a simple mission. Results are printed to the console and stored in a local SQLite database (`memory/memory.db`). The Trainer agent also records learned facts in the in-memory knowledge base.
 
 ## 🧪 Running Tests
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,13 @@
+from .builder import BuilderAgent
+from .thinker import ThinkerAgent
+from .artist import ArtistAgent
+from .guardian import GuardianAgent
+from .trainer import TrainerAgent
+
+__all__ = [
+    "BuilderAgent",
+    "ThinkerAgent",
+    "ArtistAgent",
+    "GuardianAgent",
+    "TrainerAgent",
+]

--- a/agents/trainer.py
+++ b/agents/trainer.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import Agent
+
+if TYPE_CHECKING:
+    from memory.storage import Memory
+    from knowledge_base.local_kb import KnowledgeBase
+
+
+class TrainerAgent(Agent):
+    """Agent that teaches new facts to the knowledge base."""
+
+    def __init__(self, name: str, memory: "Memory", kb: "KnowledgeBase"):
+        super().__init__(name, memory)
+        self.kb = kb
+
+    def perform_task(self, task: str):
+        self.kb.add_fact(task, f"taught by {self.name}")
+        result = f"Trainer {self.name} taught '{task}'"
+        self.remember(task, result)
+        return result

--- a/main.py
+++ b/main.py
@@ -2,23 +2,28 @@ from agents.builder import BuilderAgent
 from agents.thinker import ThinkerAgent
 from agents.artist import ArtistAgent
 from agents.guardian import GuardianAgent
+from agents.trainer import TrainerAgent
+from knowledge_base.local_kb import KnowledgeBase
 from memory.storage import Memory
 from mission_system.mission import Mission
 
 
 def main():
     memory = Memory()
+    kb = KnowledgeBase()
     agents = [
         BuilderAgent("Builder", memory),
         ThinkerAgent("Thinker", memory),
         ArtistAgent("Artist", memory),
         GuardianAgent("Guardian", memory),
+        TrainerAgent("Trainer", memory, kb),
     ]
     mission = Mission([
         "design module",
         "analyze requirements",
         "create logo",
         "check security",
+        "teach python",
     ])
 
     while not mission.is_finished():

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,17 @@
+from agents.trainer import TrainerAgent
+from knowledge_base.local_kb import KnowledgeBase
+from memory.storage import Memory
+
+
+def test_trainer_adds_fact(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    kb = KnowledgeBase()
+    agent = TrainerAgent("Teacher", memory, kb)
+
+    result = agent.perform_task("math basics")
+
+    assert result == "Trainer Teacher taught 'math basics'"
+    assert kb.query("math basics") == "taught by Teacher"
+
+    memory.close()


### PR DESCRIPTION
## Summary
- create `TrainerAgent` that teaches tasks to the knowledge base
- expose agents from `agents.__init__`
- update demo in `main.py` to include the new agent and a new mission task
- document the new agent in README
- add tests covering `TrainerAgent`

## Testing
- `pytest -q`
- `python main.py | head`

------
https://chatgpt.com/codex/tasks/task_e_685624e34c9883249b2c05c9fa512f8c