### PR TITLE
Add extended demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ bash install.sh
    python main.py
    ```
 
-The demo spawns five agents—Builder, Thinker, Artist, Guardian, and Trainer—who work together on a simple mission. Results are printed to the console and stored in a local SQLite database (`memory/memory.db`). The Trainer agent also records learned facts in the in-memory knowledge base.
+3. Run the extended demo (takes longer to complete):
+
+   ```bash
+   python long_demo.py
+   ```
+
+The demo spawns five agents—Builder, Thinker, Artist, Guardian, and Trainer—who work together on a simple mission. Results are printed to the console and stored in a local SQLite database (`memory/memory.db`). The Trainer agent also records learned facts in the in-memory knowledge base. The extended demo runs through 20 tasks with a short delay after each agent action to make the process take noticeably longer.
 
 ## 🧪 Running Tests
 

--- a/long_demo.py
+++ b/long_demo.py
@@ -1,0 +1,46 @@
+import time
+
+from agents.builder import BuilderAgent
+from agents.thinker import ThinkerAgent
+from agents.artist import ArtistAgent
+from agents.guardian import GuardianAgent
+from agents.trainer import TrainerAgent
+from knowledge_base.local_kb import KnowledgeBase
+from memory.storage import Memory
+from mission_system.mission import Mission
+
+
+def main():
+    """Run a longer mission demo to showcase agent collaboration."""
+    memory = Memory()
+    kb = KnowledgeBase()
+    agents = [
+        BuilderAgent("Builder", memory),
+        ThinkerAgent("Thinker", memory),
+        ArtistAgent("Artist", memory),
+        GuardianAgent("Guardian", memory),
+        TrainerAgent("Trainer", memory, kb),
+    ]
+
+    # Larger set of tasks to make the demo run longer
+    tasks = [
+        f"task {i}" for i in range(1, 21)
+    ]
+    mission = Mission(tasks)
+
+    while not mission.is_finished():
+        for agent in agents:
+            agent.act(mission)
+            time.sleep(0.1)
+            if mission.is_finished():
+                break
+
+    print("Extended mission completed:")
+    for task, result in mission.completed:
+        print(f"- {task}: {result}")
+
+    memory.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `long_demo.py` with 20-task mission and delay to show a longer run
- document the extended demo in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562689a868832487a134ab2a96b906