### PR TITLE
Implement verbose colored debug output

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -8,12 +8,21 @@ if TYPE_CHECKING:
     from mission_system.mission import Mission
 
 
+from colorama import Fore, Style, init
+
+
 class Agent:
     """Base class for all agents."""
     def __init__(self, name: str, memory: 'Memory'):
         self.name = name
         self.id = str(uuid.uuid4())
         self.memory = memory
+        self.verbose = False
+
+    def _debug(self, message: str) -> None:
+        if self.verbose:
+            init(autoreset=True)
+            print(f"{Fore.CYAN}{message}{Style.RESET_ALL}")
 
     def remember(self, key: str, value: Any) -> None:
         self.memory.store(f"{self.id}:{key}", value)
@@ -26,8 +35,10 @@ class Agent:
         task = mission.next_task()
         if task is None:
             return
+        self._debug(f"{self.name} starting '{task}'")
         result = self.perform_task(task)
         mission.complete_task(task, result)
+        self._debug(f"{self.name} finished '{task}'")
 
     def perform_task(self, task: str) -> Any:
         """Override in subclasses with actual behavior."""

--- a/long_demo.py
+++ b/long_demo.py
@@ -1,4 +1,5 @@
 import time
+import argparse
 
 from agents.builder import BuilderAgent
 from agents.thinker import ThinkerAgent
@@ -12,6 +13,10 @@ from mission_system.mission import Mission
 
 def main():
     """Run a longer mission demo to showcase agent collaboration."""
+    parser = argparse.ArgumentParser(description="Run an extended mission demo")
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose output")
+    args = parser.parse_args()
+
     memory = Memory()
     kb = KnowledgeBase()
     agents = [
@@ -26,6 +31,8 @@ def main():
     tasks = [
         f"task {i}" for i in range(1, 21)
     ]
+    for agent in agents:
+        agent.verbose = args.verbose
     mission = Mission(tasks)
 
     while not mission.is_finished():

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import argparse
+
 from agents.builder import BuilderAgent
 from agents.thinker import ThinkerAgent
 from agents.artist import ArtistAgent
@@ -9,6 +11,10 @@ from mission_system.mission import Mission
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Run a short mission")
+    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose output")
+    args = parser.parse_args()
+
     memory = Memory()
     kb = KnowledgeBase()
     agents = [
@@ -18,6 +24,9 @@ def main():
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),
     ]
+    for agent in agents:
+        agent.verbose = args.verbose
+
     mission = Mission([
         "design module",
         "analyze requirements",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+colorama


### PR DESCRIPTION
## Summary
- add verbose flag to command line interfaces
- colorize debug output using colorama
- display task lifecycle messages when verbose is enabled
- include `colorama` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685627d6250c832491468f1ba5f41e4f