### PR TITLE
Fix argparse line length

### DIFF
--- a/demo_sample.py
+++ b/demo_sample.py
@@ -13,7 +13,12 @@ from mission_system.mission import Mission
 def main():
     """Run a very small demo mission."""
     parser = argparse.ArgumentParser(description="Run a sample mission")
-    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose output")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose output",
+    )
     args = parser.parse_args()
 
     memory = Memory()

--- a/long_demo.py
+++ b/long_demo.py
@@ -13,8 +13,15 @@ from mission_system.mission import Mission
 
 def main():
     """Run a longer mission demo to showcase agent collaboration."""
-    parser = argparse.ArgumentParser(description="Run an extended mission demo")
-    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose output")
+    parser = argparse.ArgumentParser(
+        description="Run an extended mission demo"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose output",
+    )
     args = parser.parse_args()
 
     memory = Memory()

--- a/main.py
+++ b/main.py
@@ -12,7 +12,12 @@ from mission_system.mission import Mission
 
 def main():
     parser = argparse.ArgumentParser(description="Run a short mission")
-    parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose output")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose output",
+    )
     args = parser.parse_args()
 
     memory = Memory()


### PR DESCRIPTION
## Summary
- format argparse lines for flake8

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa70dace08324ac3c848da76b4777