### PR TITLE
Integrate Ollama for Thinker agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is the foundation of a sandbox-style ecosystem for intelligent agents. We�
 - Python 3 (no external dependencies except `pytest` for tests)
 - SQLite for persistent memory
 - Simple plugin loader for extensibility
+- [Ollama](https://ollama.com) for local LLM interaction (uses the `llama3` model by default)
 
 ## 🛠️ Ubuntu Installation
 
@@ -77,6 +78,19 @@ bash install.sh
 
    This script runs missions in an endless loop, creating a new set of tasks on
    each iteration. Stop it with `Ctrl+C`.
+
+### Ollama Support
+
+The `ThinkerAgent` uses the [Ollama](https://ollama.com) service for language
+generation. Make sure the Ollama server is running and that you have pulled a
+model, for example:
+
+```bash
+ollama pull llama3
+```
+
+Without Ollama running, the Thinker agent will return an error message in place
+of a response.
 
 The demo spawns five agents—Builder, Thinker, Artist, Guardian, and Trainer—who work together on a simple mission. Results are printed to the console and stored in a local SQLite database (`memory/memory.db`). The Trainer agent also records learned facts in the in-memory knowledge base. The extended demo runs through 20 tasks with a short delay after each agent action to make the process take noticeably longer.
 

--- a/agents/thinker.py
+++ b/agents/thinker.py
@@ -1,8 +1,22 @@
+from typing import TYPE_CHECKING
+
 from .base import Agent
+from llm.ollama_client import generate_response
+
+if TYPE_CHECKING:
+    from memory.storage import Memory
 
 
 class ThinkerAgent(Agent):
+    """Agent that reasons about a task using an LLM via Ollama."""
+
+    def __init__(self, name: str, memory: "Memory", model: str = "llama3"):
+        super().__init__(name, memory)
+        self.model = model
+
     def perform_task(self, task: str):
-        result = f"Thinker {self.name} contemplated '{task}'"
+        prompt = f"Please help with the following task: {task}"
+        response = generate_response(prompt, model=self.model)
+        result = f"Thinker {self.name} says: {response}"
         self.remember(task, result)
         return result

--- a/auto_run.py
+++ b/auto_run.py
@@ -28,7 +28,7 @@ def main(verbose: bool = False, sleep: float = 5.0) -> None:
     kb = KnowledgeBase()
     agents = [
         BuilderAgent("Builder", memory),
-        ThinkerAgent("Thinker", memory),
+        ThinkerAgent("Thinker", memory, model="llama3"),
         ArtistAgent("Artist", memory),
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),

--- a/demo_sample.py
+++ b/demo_sample.py
@@ -25,7 +25,7 @@ def main():
     kb = KnowledgeBase()
     agents = [
         BuilderAgent("Builder", memory),
-        ThinkerAgent("Thinker", memory),
+        ThinkerAgent("Thinker", memory, model="llama3"),
         ArtistAgent("Artist", memory),
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,1 @@
+from .ollama_client import generate_response

--- a/llm/ollama_client.py
+++ b/llm/ollama_client.py
@@ -1,0 +1,18 @@
+import ollama
+
+
+def generate_response(prompt: str, model: str = "llama3") -> str:
+    """Return the response from the Ollama model.
+
+    Parameters
+    ----------
+    prompt : str
+        The user prompt to send to the model.
+    model : str, optional
+        The model to use, by default "llama3".
+    """
+    try:
+        response = ollama.chat(model=model, messages=[{"role": "user", "content": prompt}])
+        return response.get("message", {}).get("content", "").strip()
+    except Exception as exc:
+        return f"[ollama error: {exc}]"

--- a/long_demo.py
+++ b/long_demo.py
@@ -28,7 +28,7 @@ def main():
     kb = KnowledgeBase()
     agents = [
         BuilderAgent("Builder", memory),
-        ThinkerAgent("Thinker", memory),
+        ThinkerAgent("Thinker", memory, model="llama3"),
         ArtistAgent("Artist", memory),
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def main():
     kb = KnowledgeBase()
     agents = [
         BuilderAgent("Builder", memory),
-        ThinkerAgent("Thinker", memory),
+        ThinkerAgent("Thinker", memory, model="llama3"),
         ArtistAgent("Artist", memory),
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 colorama
+ollama


### PR DESCRIPTION
## Summary
- add `llm` package with helper to call Ollama
- update `ThinkerAgent` to use Ollama LLM responses
- pass default model parameter when creating Thinker agents
- document Ollama requirement in the README
- list `ollama` in dependencies

## Testing
- `pip install colorama ollama --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b48a59f748324b90d30a395b346e1