### PR TITLE
Switch to Ollama defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,19 @@ The `ThinkerAgent` uses the [Ollama](https://ollama.com) service for language
 generation. Make sure the Ollama server is running and that you have pulled a
 model, for example:
 
+
 ```bash
 ollama pull llama3
+ollama serve &  # start the Ollama server in the background
+```
+
+By default the Thinker agent uses the model specified in the ``OLLAMA_MODEL``
+environment variable (``llama3`` if unset). You can override it when launching
+the application:
+
+```bash
+export OLLAMA_MODEL=mistral
+python main.py
 ```
 
 Without Ollama running, the Thinker agent will return an error message in place

--- a/agents/thinker.py
+++ b/agents/thinker.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from .base import Agent
-from llm.ollama_client import generate_response
+from llm.ollama_client import DEFAULT_MODEL, generate_response
 
 if TYPE_CHECKING:
     from memory.storage import Memory
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 class ThinkerAgent(Agent):
     """Agent that reasons about a task using an LLM via Ollama."""
 
-    def __init__(self, name: str, memory: "Memory", model: str = "llama3"):
+    def __init__(self, name: str, memory: "Memory", model: str = DEFAULT_MODEL):
         super().__init__(name, memory)
         self.model = model
 

--- a/llm/ollama_client.py
+++ b/llm/ollama_client.py
@@ -1,7 +1,12 @@
+"""Thin wrapper around the Ollama Python client."""
+
+import os
 import ollama
 
+DEFAULT_MODEL = os.getenv("OLLAMA_MODEL", "llama3")
 
-def generate_response(prompt: str, model: str = "llama3") -> str:
+
+def generate_response(prompt: str, model: str | None = None) -> str:
     """Return the response from the Ollama model.
 
     Parameters
@@ -9,8 +14,11 @@ def generate_response(prompt: str, model: str = "llama3") -> str:
     prompt : str
         The user prompt to send to the model.
     model : str, optional
-        The model to use, by default "llama3".
+        The model to use. If not provided, the ``OLLAMA_MODEL`` environment
+        variable is used, falling back to ``llama3``.
     """
+    if model is None:
+        model = DEFAULT_MODEL
     try:
         response = ollama.chat(model=model, messages=[{"role": "user", "content": prompt}])
         return response.get("message", {}).get("content", "").strip()


### PR DESCRIPTION
## Summary
- add `OLLAMA_MODEL` environment variable support
- use the env-var default in Thinker agent
- document starting the Ollama server and customizing the model

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd2824c348324bc7e78eb21e4a589