### PR TITLE
Add plugin loader and safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is the foundation of a sandbox-style ecosystem for intelligent agents. We�
 - 📚 Local knowledge base + self-learning loop
 - ⚙️ Event-driven behaviors, mission triggers, and growth protocols
 - 🧩 Plugin-ready system to add roles, logic, and behavior profiles
+- 🛡️ Guardian failsafe blocks unsafe tasks
+- 🌐 Ollama usage falls back gracefully when offline
 
 ## 🚀 Goals
 
@@ -74,6 +76,12 @@ bash install.sh
 
    ```bash
    python auto_run.py -v
+   ```
+
+6. Load plugin agents using `--plugin-package`:
+
+   ```bash
+   python main.py --plugin-package plugins.agents
    ```
 
    This script runs missions in an endless loop, creating a new set of tasks on

--- a/agents/guardian.py
+++ b/agents/guardian.py
@@ -2,7 +2,12 @@ from .base import Agent
 
 
 class GuardianAgent(Agent):
+    banned_keywords = {"harm", "malware", "attack"}
+
     def perform_task(self, task: str):
-        result = f"Guardian {self.name} secured '{task}'"
+        if any(bad in task.lower() for bad in self.banned_keywords):
+            result = f"Guardian {self.name} blocked unsafe task"
+        else:
+            result = f"Guardian {self.name} secured '{task}'"
         self.remember(task, result)
         return result

--- a/agents/trainer.py
+++ b/agents/trainer.py
@@ -17,7 +17,10 @@ class TrainerAgent(Agent):
         self.kb = kb
 
     def perform_task(self, task: str):
-        self.kb.add_fact(task, f"taught by {self.name}")
-        result = f"Trainer {self.name} taught '{task}'"
+        if self.kb.query(task):
+            result = f"Trainer {self.name} already knew '{task}'"
+        else:
+            self.kb.add_fact(task, f"taught by {self.name}")
+            result = f"Trainer {self.name} taught '{task}'"
         self.remember(task, result)
         return result

--- a/llm/ollama_client.py
+++ b/llm/ollama_client.py
@@ -3,6 +3,15 @@
 import os
 import ollama
 
+
+def is_ollama_available() -> bool:
+    """Return True if the Ollama server is reachable."""
+    try:
+        ollama.list_models()
+        return True
+    except Exception:
+        return False
+
 DEFAULT_MODEL = os.getenv("OLLAMA_MODEL", "llama3")
 
 
@@ -19,6 +28,8 @@ def generate_response(prompt: str, model: str | None = None) -> str:
     """
     if model is None:
         model = DEFAULT_MODEL
+    if not is_ollama_available():
+        return "[ollama offline]"
     try:
         response = ollama.chat(model=model, messages=[{"role": "user", "content": prompt}])
         return response.get("message", {}).get("content", "").strip()

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 import argparse
 
+from agents.base import Agent
 from agents.builder import BuilderAgent
 from agents.thinker import ThinkerAgent
 from agents.artist import ArtistAgent
 from agents.guardian import GuardianAgent
 from agents.trainer import TrainerAgent
+from plugins.loader import load_plugins
 from knowledge_base.local_kb import KnowledgeBase
 from memory.storage import Memory
 from mission_system.mission import Mission
@@ -18,6 +20,11 @@ def main():
         action="store_true",
         help="enable verbose output",
     )
+    parser.add_argument(
+        "--plugin-package",
+        default=None,
+        help="optional plugin package to load agents from",
+    )
     args = parser.parse_args()
 
     memory = Memory()
@@ -29,6 +36,16 @@ def main():
         GuardianAgent("Guardian", memory),
         TrainerAgent("Trainer", memory, kb),
     ]
+    if args.plugin_package:
+        for module in load_plugins(args.plugin_package):
+            for attr in dir(module):
+                cls = getattr(module, attr)
+                if (
+                    isinstance(cls, type)
+                    and issubclass(cls, Agent)
+                    and cls is not Agent
+                ):
+                    agents.append(cls(cls.__name__, memory))
     for agent in agents:
         agent.verbose = args.verbose
 

--- a/mission_system/mission.py
+++ b/mission_system/mission.py
@@ -1,10 +1,11 @@
-from typing import List, Any, Optional
+from typing import Any, Callable, List, Optional
 
 
 class Mission:
-    def __init__(self, tasks: List[str]):
+    def __init__(self, tasks: List[str], on_complete: Callable[[str, Any], None] | None = None):
         self.tasks = tasks
         self.completed = []
+        self.on_complete = on_complete
 
     def next_task(self) -> Optional[str]:
         if not self.tasks:
@@ -13,6 +14,8 @@ class Mission:
 
     def complete_task(self, task: str, result: Any) -> None:
         self.completed.append((task, result))
+        if self.on_complete:
+            self.on_complete(task, result)
 
     def is_finished(self) -> bool:
         return not self.tasks

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin package for dynamic agents."""

--- a/plugins/agents/__init__.py
+++ b/plugins/agents/__init__.py
@@ -1,0 +1,2 @@
+from .echo import EchoAgent
+__all__ = ["EchoAgent"]

--- a/plugins/agents/echo.py
+++ b/plugins/agents/echo.py
@@ -1,0 +1,10 @@
+from agents.base import Agent
+
+
+class EchoAgent(Agent):
+    """Simple plugin agent that echoes tasks."""
+
+    def perform_task(self, task: str):
+        result = f"Echo {self.name}: {task}"
+        self.remember(task, result)
+        return result

--- a/tests/test_guardian.py
+++ b/tests/test_guardian.py
@@ -1,0 +1,13 @@
+from agents.guardian import GuardianAgent
+from memory.storage import Memory
+
+
+def test_guardian_blocks(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    agent = GuardianAgent("Guard", memory)
+    result_safe = agent.perform_task("secure data")
+    result_bad = agent.perform_task("launch malware attack")
+    assert result_safe == "Guardian Guard secured 'secure data'"
+    assert result_bad == "Guardian Guard blocked unsafe task"
+    memory.close()

--- a/tests/test_mission_event.py
+++ b/tests/test_mission_event.py
@@ -1,0 +1,14 @@
+from mission_system.mission import Mission
+
+
+def test_mission_on_complete():
+    events = []
+
+    def callback(task, result):
+        events.append((task, result))
+
+    mission = Mission(["a"], on_complete=callback)
+    mission.next_task()
+    mission.complete_task("a", "done")
+
+    assert events == [("a", "done")]

--- a/tests/test_ollama_offline.py
+++ b/tests/test_ollama_offline.py
@@ -1,0 +1,5 @@
+from llm.ollama_client import is_ollama_available
+
+
+def test_is_ollama_available_returns_bool():
+    assert isinstance(is_ollama_available(), bool)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,6 @@
+from plugins.loader import load_plugins
+
+
+def test_load_plugins():
+    modules = load_plugins('plugins.agents')
+    assert any(hasattr(m, 'EchoAgent') for m in modules)

--- a/tests/test_trainer_duplicate.py
+++ b/tests/test_trainer_duplicate.py
@@ -1,0 +1,17 @@
+from agents.trainer import TrainerAgent
+from knowledge_base.local_kb import KnowledgeBase
+from memory.storage import Memory
+
+
+def test_trainer_handles_duplicate(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    kb = KnowledgeBase()
+    agent = TrainerAgent("Teach", memory, kb)
+
+    first = agent.perform_task("math")
+    second = agent.perform_task("math")
+
+    assert first == "Trainer Teach taught 'math'"
+    assert second == "Trainer Teach already knew 'math'"
+    memory.close()


### PR DESCRIPTION
## Summary
- allow optional plugin agents via `--plugin-package`
- emit callbacks when mission tasks complete
- block unsafe tasks with Guardian agent
- make Trainer agent reuse knowledge
- handle offline Ollama usage
- include demo instructions for plugin loading
- add tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8e66cd248324aff77a160e918af2