### PR TITLE
Add utility features

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -19,6 +19,14 @@ class Agent:
         self.memory = memory
         self.verbose = False
 
+    def set_verbose(self, verbose: bool) -> None:
+        """Enable or disable verbose debug output."""
+        self.verbose = verbose
+
+    def describe(self) -> str:
+        """Return a short description of the agent."""
+        return f"{self.name} ({self.id})"
+
     def _debug(self, message: str) -> None:
         if self.verbose:
             init(autoreset=True)

--- a/agents/guardian.py
+++ b/agents/guardian.py
@@ -4,6 +4,11 @@ from .base import Agent
 class GuardianAgent(Agent):
     banned_keywords = {"harm", "malware", "attack"}
 
+    @classmethod
+    def add_banned_keyword(cls, word: str) -> None:
+        """Add a new banned keyword to the shared list."""
+        cls.banned_keywords.add(word.lower())
+
     def perform_task(self, task: str):
         if any(bad in task.lower() for bad in self.banned_keywords):
             result = f"Guardian {self.name} blocked unsafe task"

--- a/memory/storage.py
+++ b/memory/storage.py
@@ -34,5 +34,17 @@ class Memory:
         row = cur.fetchone()
         return row[0] if row else None
 
+    def delete(self, key: str) -> None:
+        """Remove a value from memory if it exists."""
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM memory WHERE key = ?", (key,))
+        self.conn.commit()
+
+    def keys(self) -> list[str]:
+        """Return a list of all stored keys."""
+        cur = self.conn.cursor()
+        cur.execute("SELECT key FROM memory")
+        return [row[0] for row in cur.fetchall()]
+
     def close(self) -> None:
         self.conn.close()

--- a/mission_system/mission.py
+++ b/mission_system/mission.py
@@ -25,3 +25,7 @@ class Mission:
         total = len(self.completed) + len(self.tasks)
         completed = len(self.completed)
         return f"{completed}/{total} tasks completed"
+
+    def get_remaining_tasks(self) -> List[str]:
+        """Return a copy of the remaining tasks."""
+        return list(self.tasks)

--- a/tests/test_agent_features.py
+++ b/tests/test_agent_features.py
@@ -1,0 +1,13 @@
+from agents.builder import BuilderAgent
+from memory.storage import Memory
+
+
+def test_set_verbose_and_describe(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    agent = BuilderAgent("B", memory)
+    agent.set_verbose(True)
+    assert agent.verbose is True
+    desc = agent.describe()
+    assert agent.name in desc and agent.id in desc
+    memory.close()

--- a/tests/test_guardian_add_keyword.py
+++ b/tests/test_guardian_add_keyword.py
@@ -1,0 +1,12 @@
+from agents.guardian import GuardianAgent
+from memory.storage import Memory
+
+
+def test_add_banned_keyword(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    GuardianAgent.add_banned_keyword("virus")
+    agent = GuardianAgent("G", memory)
+    result = agent.perform_task("launch virus")
+    assert result == "Guardian G blocked unsafe task"
+    memory.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -9,3 +9,15 @@ def test_store_and_get(tmp_path):
     assert memory.get("foo") == "bar"
     memory.close()
     os.remove(db_path)
+
+
+def test_delete_and_keys(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    memory.store("a", "1")
+    memory.store("b", "2")
+    assert set(memory.keys()) == {"a", "b"}
+    memory.delete("a")
+    assert memory.get("a") is None
+    assert set(memory.keys()) == {"b"}
+    memory.close()

--- a/tests/test_mission_remaining.py
+++ b/tests/test_mission_remaining.py
@@ -1,0 +1,8 @@
+from mission_system.mission import Mission
+
+
+def test_get_remaining_tasks():
+    mission = Mission(["a", "b"])
+    assert mission.get_remaining_tasks() == ["a", "b"]
+    mission.next_task()
+    assert mission.get_remaining_tasks() == ["b"]


### PR DESCRIPTION
## Summary
- introduce delete() and keys() helpers for Memory
- allow Agents to set verbosity and describe themselves
- add ability to register new banned keywords in GuardianAgent
- expose remaining tasks for Mission
- add tests for new features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4765dd38832485c2a33a680b0afa