### PR TITLE
Implement new utility features

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -38,6 +38,11 @@ class Agent:
     def recall(self, key: str) -> Any:
         return self.memory.get(f"{self.id}:{key}")
 
+    def get_memory_keys(self) -> list[str]:
+        """Return all memory keys stored for this agent."""
+        prefix = f"{self.id}:"
+        return [k[len(prefix):] for k in self.memory.keys() if k.startswith(prefix)]
+
     def act(self, mission: 'Mission') -> None:
         """Perform a single step for the mission."""
         task = mission.next_task()

--- a/knowledge_base/local_kb.py
+++ b/knowledge_base/local_kb.py
@@ -8,3 +8,7 @@ class KnowledgeBase:
 
     def query(self, key: str) -> str:
         return self.facts.get(key, "")
+
+    def delete_fact(self, key: str) -> None:
+        """Remove a fact if it exists."""
+        self.facts.pop(key, None)

--- a/memory/storage.py
+++ b/memory/storage.py
@@ -40,6 +40,12 @@ class Memory:
         cur.execute("DELETE FROM memory WHERE key = ?", (key,))
         self.conn.commit()
 
+    def clear(self) -> None:
+        """Remove all key/value pairs from memory."""
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM memory")
+        self.conn.commit()
+
     def keys(self) -> list[str]:
         """Return a list of all stored keys."""
         cur = self.conn.cursor()

--- a/mission_system/mission.py
+++ b/mission_system/mission.py
@@ -29,3 +29,10 @@ class Mission:
     def get_remaining_tasks(self) -> List[str]:
         """Return a copy of the remaining tasks."""
         return list(self.tasks)
+
+    def reset(self, tasks: Optional[List[str]] | None = None) -> None:
+        """Reset the mission with optional new tasks."""
+        if tasks is None:
+            tasks = [t for t, _ in self.completed] + self.tasks
+        self.tasks = list(tasks)
+        self.completed.clear()

--- a/plugins/loader.py
+++ b/plugins/loader.py
@@ -12,3 +12,9 @@ def load_plugins(package: str) -> List[ModuleType]:
         full_name = f"{package}.{info.name}"
         modules.append(importlib.import_module(full_name))
     return modules
+
+
+def discover_plugins(package: str) -> List[str]:
+    """Return a list of available plugin module names without importing them."""
+    pkg = importlib.import_module(package)
+    return [f"{package}.{info.name}" for info in pkgutil.iter_modules(pkg.__path__)]

--- a/tests/test_agent_features.py
+++ b/tests/test_agent_features.py
@@ -11,3 +11,12 @@ def test_set_verbose_and_describe(tmp_path):
     desc = agent.describe()
     assert agent.name in desc and agent.id in desc
     memory.close()
+
+
+def test_get_memory_keys(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    agent = BuilderAgent("B", memory)
+    agent.perform_task("build")
+    assert agent.get_memory_keys() == ["build"]
+    memory.close()

--- a/tests/test_kb_delete.py
+++ b/tests/test_kb_delete.py
@@ -1,0 +1,9 @@
+from knowledge_base.local_kb import KnowledgeBase
+
+
+def test_delete_fact():
+    kb = KnowledgeBase()
+    kb.add_fact('a', '1')
+    assert kb.query('a') == '1'
+    kb.delete_fact('a')
+    assert kb.query('a') == ''

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -21,3 +21,13 @@ def test_delete_and_keys(tmp_path):
     assert memory.get("a") is None
     assert set(memory.keys()) == {"b"}
     memory.close()
+
+
+def test_clear(tmp_path):
+    db_path = tmp_path / "test.db"
+    memory = Memory(db_path)
+    memory.store("x", "1")
+    memory.store("y", "2")
+    memory.clear()
+    assert memory.keys() == []
+    memory.close()

--- a/tests/test_mission_reset.py
+++ b/tests/test_mission_reset.py
@@ -1,0 +1,10 @@
+from mission_system.mission import Mission
+
+
+def test_reset_mission():
+    mission = Mission(["a", "b"])
+    mission.next_task()
+    mission.complete_task("a", "done")
+    mission.reset()
+    assert mission.completed == []
+    assert mission.get_remaining_tasks() == ["a", "b"]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,6 +1,11 @@
-from plugins.loader import load_plugins
+from plugins.loader import load_plugins, discover_plugins
 
 
 def test_load_plugins():
     modules = load_plugins('plugins.agents')
     assert any(hasattr(m, 'EchoAgent') for m in modules)
+
+
+def test_discover_plugins():
+    names = discover_plugins('plugins.agents')
+    assert 'plugins.agents.echo' in names


### PR DESCRIPTION
## Summary
- add `Memory.clear` for wiping storage
- implement `Mission.reset` to restart tasks
- expose new `discover_plugins` in plugin loader
- allow agents to list their memory keys
- support removing facts from `KnowledgeBase`
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4c41448c8324a0d08cbb21143e59